### PR TITLE
fix/code-review-improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,24 +29,35 @@ This Terraform project manages **global AWS infrastructure** components that ser
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
 | [Terraform Validation](.github/workflows/terraform-validation.yml) | On every PR/push | Validates syntax and formatting |
-| [PR Plan](.github/workflows/terraform-pr-plan.yml) | PRs to main | Shows planned changes |
-| [Apply Changes](.github/workflows/terraform-apply.yml) | Merge to main | Deploys infrastructure |
+| [Terraform Plan](.github/workflows/terraform-pr-plan.yml) | On PRs to main | Shows planned changes |
+| [Terraform Apply](.github/workflows/terraform-apply.yml) | After merge to main | Automatically deploys infrastructure |
 
 ### Required Secrets
 
-These secrets must be configured in your CI/CD environment:
+Configure these secrets in your GitHub repository settings:
 
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `AWS_ACCESS_KEY_ID` | AWS IAM Access Key | AKIAXXXXXXXXXXXXXXXX |
-| `AWS_SECRET_ACCESS_KEY` | AWS IAM Secret Key | **************************************** |
-| `AWS_DEFAULT_REGION` | Default AWS Region | us-east-1 |
+| Variable | Description | Required For |
+|----------|-------------|--------------|
+| `AWS_ACCESS_KEY_ID` | AWS IAM Access Key | Plan & Apply workflows |
+| `AWS_SECRET_ACCESS_KEY` | AWS IAM Secret Key | Plan & Apply workflows |
+| `TERRAFORM_BACKEND_BUCKET` | S3 bucket for Terraform state | Plan & Apply workflows |
+
+### Pipeline Flow
+
+```
+PR Created → Validation → Plan → Review → Merge to Main → Apply
+```
 
 ## Usage Guidelines
 
 ### Local Development
 
-1. Clone the repository
+1. Clone the repository:
+   ```bash
+   git clone git@personal.github.com:shahid-2020/infrastructure-aws-manager.git
+   cd infrastructure-aws-manager
+   ```
+
 2. Initialize Terraform:
    ```bash
    cd main

--- a/main/modules/db-subnet-group/README.md
+++ b/main/modules/db-subnet-group/README.md
@@ -1,0 +1,49 @@
+# DB Subnet Group Module
+
+This module creates a DB subnet group for RDS database instances. DB subnet groups allow you to specify which subnets your RDS instances can be launched in.
+
+## Resources Created
+
+- `aws_db_subnet_group` - The DB subnet group resource
+
+## Usage
+
+```hcl
+module "db_subnet_group" {
+  source = "./modules/db-subnet-group"
+
+  name       = "main-private-db-subnet-group"
+  subnet_ids = ["subnet-12345678", "subnet-87654321"]
+
+  tags = {
+    Name = "main-private-db-subnet-group"
+  }
+}
+```
+
+## Input Variables
+
+| Name | Type | Description | Required | Default |
+|------|------|-------------|----------|---------|
+| `name` | `string` | Name of the DB subnet group (must be unique within AWS account) | Yes | - |
+| `subnet_ids` | `list(string)` | List of subnet IDs (must include at least 2 subnets in different AZs) | Yes | - |
+| `tags` | `map(string)` | A map of tags to assign to the DB subnet group | No | `{}` |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `id` | The ID of the DB subnet group |
+
+## Requirements
+
+- At least 2 subnets in different availability zones for high availability
+- Subnets must be in the same VPC
+- Recommended to use private subnets for database instances
+
+## Notes
+
+- DB subnet groups are required for RDS instances (not required for RDS Aurora clusters in some cases)
+- Subnets should be private subnets to keep databases secure
+- The subnet group name must be unique within your AWS account and region
+

--- a/main/modules/db-subnet-group/variables.tf
+++ b/main/modules/db-subnet-group/variables.tf
@@ -1,12 +1,25 @@
 variable "name" {
-  type = string
+  type        = string
+  description = "Name of the DB subnet group. Must be unique within the AWS account."
+
+  validation {
+    condition     = length(var.name) > 0 && length(var.name) <= 255
+    error_message = "name must be between 1 and 255 characters."
+  }
 }
 
 variable "subnet_ids" {
-  type = list(string)
+  type        = list(string)
+  description = "List of subnet IDs for the DB subnet group. Must include subnets in at least 2 availability zones."
+
+  validation {
+    condition     = length(var.subnet_ids) >= 2
+    error_message = "subnet_ids must contain at least 2 subnets for high availability."
+  }
 }
 
 variable "tags" {
-  type    = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
+  description = "A map of tags to assign to the DB subnet group."
 }

--- a/main/modules/ecs-cluster/README.md
+++ b/main/modules/ecs-cluster/README.md
@@ -1,0 +1,48 @@
+# ECS Cluster Module
+
+This module creates an Amazon Elastic Container Service (ECS) cluster with Container Insights enabled for monitoring.
+
+## Resources Created
+
+- `aws_ecs_cluster` - The ECS cluster resource
+
+## Usage
+
+```hcl
+module "ecs_cluster" {
+  source = "./modules/ecs-cluster"
+
+  name = "production"
+
+  tags = {
+    Name        = "production-ecs-cluster"
+    Environment = "production"
+  }
+}
+```
+
+## Input Variables
+
+| Name | Type | Description | Required | Default |
+|------|------|-------------|----------|---------|
+| `name` | `string` | Name of the ECS cluster (must be unique within AWS account and region) | Yes | - |
+| `tags` | `map(string)` | A map of tags to assign to the ECS cluster | No | `{}` |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `id` | The ID of the ECS cluster |
+| `arn` | The ARN of the ECS cluster |
+
+## Features
+
+- Container Insights enabled for enhanced monitoring and observability
+- Automatically configured for both Fargate and EC2 launch types
+
+## Notes
+
+- Container Insights provides detailed metrics and logs for your containers
+- Cluster names can contain alphanumeric characters, hyphens, and underscores
+- An empty cluster can be created and services/tasks can be added later
+

--- a/main/modules/ecs-cluster/variables.tf
+++ b/main/modules/ecs-cluster/variables.tf
@@ -1,8 +1,20 @@
 variable "name" {
-  type = string
+  type        = string
+  description = "Name of the ECS cluster. Must be unique within the AWS account and region."
+
+  validation {
+    condition     = length(var.name) > 0 && length(var.name) <= 255
+    error_message = "name must be between 1 and 255 characters."
+  }
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9-_]+$", var.name))
+    error_message = "name can only contain alphanumeric characters, hyphens, and underscores."
+  }
 }
 
 variable "tags" {
-  type    = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
+  description = "A map of tags to assign to the ECS cluster."
 }

--- a/main/modules/internet-gateway/README.md
+++ b/main/modules/internet-gateway/README.md
@@ -1,0 +1,44 @@
+# Internet Gateway Module
+
+This module creates an Internet Gateway and attaches it to a VPC. An Internet Gateway enables resources in public subnets to communicate with the internet.
+
+## Resources Created
+
+- `aws_internet_gateway` - The Internet Gateway resource
+
+## Usage
+
+```hcl
+module "igw" {
+  source = "./modules/internet-gateway"
+
+  vpc_id = "vpc-12345678"
+
+  tags = {
+    Name = "main-igw"
+    Environment = "production"
+  }
+}
+```
+
+## Input Variables
+
+| Name | Type | Description | Required | Default |
+|------|------|-------------|----------|---------|
+| `vpc_id` | `string` | The ID of the VPC to attach the Internet Gateway to | Yes | - |
+| `tags` | `map(string)` | A map of tags to assign to the Internet Gateway | No | `{}` |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `id` | The ID of the Internet Gateway |
+
+## Notes
+
+- An Internet Gateway is required for resources in public subnets to access the internet
+- Only one Internet Gateway can be attached to a VPC at a time
+- Internet Gateways are automatically redundant and highly available
+- After creating an Internet Gateway, you need to add routes to your route tables pointing internet traffic (0.0.0.0/0) to the gateway
+- Internet Gateways are free (no data transfer charges within the same region)
+

--- a/main/modules/internet-gateway/variables.tf
+++ b/main/modules/internet-gateway/variables.tf
@@ -1,8 +1,15 @@
 variable "vpc_id" {
-  type = string
+  type        = string
+  description = "The ID of the VPC to attach the Internet Gateway to."
+
+  validation {
+    condition     = length(var.vpc_id) > 0
+    error_message = "vpc_id cannot be empty."
+  }
 }
 
 variable "tags" {
-  type    = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
+  description = "A map of tags to assign to the Internet Gateway. Each tag must have a key and value."
 }

--- a/main/modules/nat-gateway/README.md
+++ b/main/modules/nat-gateway/README.md
@@ -1,0 +1,55 @@
+# NAT Gateway Module
+
+This module creates a NAT Gateway with an Elastic IP address. NAT Gateways enable resources in private subnets to initiate outbound internet connections while remaining private.
+
+## Resources Created
+
+- `aws_eip` - Elastic IP address for the NAT Gateway
+- `aws_nat_gateway` - The NAT Gateway resource
+
+## Usage
+
+```hcl
+module "nat_gateway" {
+  source = "./modules/nat-gateway"
+
+  subnet_id = "subnet-12345678"
+
+  tags = {
+    Name = "main-nat-gateway"
+    Environment = "production"
+  }
+
+  depends_on = [module.internet_gateway]
+}
+```
+
+## Input Variables
+
+| Name | Type | Description | Required | Default |
+|------|------|-------------|----------|---------|
+| `subnet_id` | `string` | The ID of the public subnet where the NAT Gateway will be placed | Yes | - |
+| `tags` | `map(string)` | A map of tags to assign to the NAT Gateway and EIP | No | `{}` |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `id` | The ID of the NAT Gateway |
+
+## Important Notes
+
+- **Placement**: NAT Gateways must be placed in a **public subnet** (with an Internet Gateway route)
+- **High Availability**: For production, create NAT Gateways in multiple AZs and route traffic accordingly
+- **Cost**: NAT Gateways incur hourly charges and data processing fees
+- **Elastic IP**: An Elastic IP is automatically created and associated with the NAT Gateway
+- **Dependencies**: Ensure the subnet has a route to an Internet Gateway before creating the NAT Gateway
+- **Private Subnets**: After creating a NAT Gateway, add routes in private subnet route tables pointing 0.0.0.0/0 to the NAT Gateway
+
+## Architecture Best Practice
+
+For high availability in production:
+1. Create NAT Gateways in multiple availability zones
+2. Create separate route tables for each private subnet in each AZ
+3. Route each private subnet's traffic to the NAT Gateway in the same AZ
+

--- a/main/modules/nat-gateway/variables.tf
+++ b/main/modules/nat-gateway/variables.tf
@@ -1,8 +1,15 @@
 variable "subnet_id" {
-  type = string
+  type        = string
+  description = "The ID of the public subnet where the NAT Gateway will be placed. The subnet must have a route to an Internet Gateway."
+
+  validation {
+    condition     = length(var.subnet_id) > 0
+    error_message = "subnet_id cannot be empty."
+  }
 }
 
 variable "tags" {
-  type    = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
+  description = "A map of tags to assign to the NAT Gateway and Elastic IP. Each tag must have a key and value."
 }

--- a/main/modules/network-acl/README.md
+++ b/main/modules/network-acl/README.md
@@ -1,0 +1,79 @@
+# Network ACL Module
+
+This module creates a Network Access Control List (NACL) for a subnet with configurable ingress and egress rules. NACLs provide an additional layer of security as a stateless firewall.
+
+## Resources Created
+
+- `aws_network_acl` - The Network ACL resource
+- `aws_network_acl_association` - Association between the NACL and subnet
+
+## Usage
+
+```hcl
+module "subnet_nacl" {
+  source = "./modules/network-acl"
+
+  vpc_id    = "vpc-12345678"
+  subnet_id = "subnet-12345678"
+  
+  ingress_rules = [
+    {
+      rule_no    = 100
+      protocol   = "tcp"
+      action     = "allow"
+      cidr_block = "10.0.0.0/16"
+      from_port  = 80
+      to_port    = 80
+    }
+  ]
+  
+  egress_rules = [
+    {
+      rule_no    = 100
+      protocol   = "-1"
+      action     = "allow"
+      cidr_block = "0.0.0.0/0"
+      from_port  = 0
+      to_port    = 0
+    }
+  ]
+
+  tags = {
+    Name = "public-subnet-nacl"
+  }
+}
+```
+
+## Input Variables
+
+| Name | Type | Description | Required | Default |
+|------|------|-------------|----------|---------|
+| `vpc_id` | `string` | The ID of the VPC | Yes | - |
+| `subnet_id` | `string` | The ID of the subnet to associate with | Yes | - |
+| `ingress_rules` | `list(object)` | List of ingress rules | Yes | - |
+| `egress_rules` | `list(object)` | List of egress rules | Yes | - |
+| `tags` | `map(string)` | A map of tags to assign to the NACL | No | `{}` |
+
+## Rule Object Structure
+
+Each rule object must contain:
+- `rule_no` (number): Rule number (1-32766, lower numbers evaluated first)
+- `protocol` (string): Protocol (-1 for all, tcp, udp, icmp, or protocol number)
+- `action` (string): Either "allow" or "deny"
+- `cidr_block` (string): CIDR block to match
+- `from_port` (number): Starting port (0 for ICMP, -1 for all)
+- `to_port` (number): Ending port (0 for ICMP, -1 for all)
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `id` | The ID of the Network ACL |
+
+## Notes
+
+- NACLs are stateless (you must explicitly allow return traffic)
+- Rules are evaluated in order (lowest rule_no first)
+- Default NACL allows all traffic; custom NACLs deny all by default
+- Each subnet must be associated with exactly one NACL
+

--- a/main/modules/network-acl/variables.tf
+++ b/main/modules/network-acl/variables.tf
@@ -1,9 +1,21 @@
 variable "vpc_id" {
-  type = string
+  type        = string
+  description = "The ID of the VPC where the Network ACL will be created."
+
+  validation {
+    condition     = length(var.vpc_id) > 0
+    error_message = "vpc_id cannot be empty."
+  }
 }
 
 variable "subnet_id" {
-  type = string
+  type        = string
+  description = "The ID of the subnet to associate with the Network ACL. Each subnet must be associated with exactly one Network ACL."
+
+  validation {
+    condition     = length(var.subnet_id) > 0
+    error_message = "subnet_id cannot be empty."
+  }
 }
 
 variable "ingress_rules" {
@@ -15,6 +27,33 @@ variable "ingress_rules" {
     from_port  = number
     to_port    = number
   }))
+  description = "List of ingress (inbound) rules for the Network ACL. Rules are evaluated in order (lowest rule_no first)."
+
+  validation {
+    condition     = length(var.ingress_rules) > 0
+    error_message = "ingress_rules must contain at least one rule."
+  }
+
+  validation {
+    condition = alltrue([
+      for rule in var.ingress_rules : rule.rule_no >= 1 && rule.rule_no <= 32766
+    ])
+    error_message = "rule_no must be between 1 and 32766 for all ingress rules."
+  }
+
+  validation {
+    condition = alltrue([
+      for rule in var.ingress_rules : contains(["allow", "deny"], lower(rule.action))
+    ])
+    error_message = "action must be either 'allow' or 'deny' for all ingress rules."
+  }
+
+  validation {
+    condition = alltrue([
+      for rule in var.ingress_rules : can(cidrhost(rule.cidr_block, 0))
+    ])
+    error_message = "All cidr_block values in ingress_rules must be valid IPv4 CIDR blocks."
+  }
 }
 
 variable "egress_rules" {
@@ -26,9 +65,37 @@ variable "egress_rules" {
     from_port  = number
     to_port    = number
   }))
+  description = "List of egress (outbound) rules for the Network ACL. Rules are evaluated in order (lowest rule_no first)."
+
+  validation {
+    condition     = length(var.egress_rules) > 0
+    error_message = "egress_rules must contain at least one rule."
+  }
+
+  validation {
+    condition = alltrue([
+      for rule in var.egress_rules : rule.rule_no >= 1 && rule.rule_no <= 32766
+    ])
+    error_message = "rule_no must be between 1 and 32766 for all egress rules."
+  }
+
+  validation {
+    condition = alltrue([
+      for rule in var.egress_rules : contains(["allow", "deny"], lower(rule.action))
+    ])
+    error_message = "action must be either 'allow' or 'deny' for all egress rules."
+  }
+
+  validation {
+    condition = alltrue([
+      for rule in var.egress_rules : can(cidrhost(rule.cidr_block, 0))
+    ])
+    error_message = "All cidr_block values in egress_rules must be valid IPv4 CIDR blocks."
+  }
 }
 
 variable "tags" {
-  type    = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
+  description = "A map of tags to assign to the Network ACL. Each tag must have a key and value."
 }

--- a/main/modules/route-table-subnet-association/README.md
+++ b/main/modules/route-table-subnet-association/README.md
@@ -1,0 +1,46 @@
+# Route Table Subnet Association Module
+
+This module associates one or more subnets with a route table. Each subnet must be associated with exactly one route table to determine how traffic is routed.
+
+## Resources Created
+
+- `aws_route_table_association` - One or more associations (one per subnet)
+
+## Usage
+
+```hcl
+module "public_subnet_route_association" {
+  source = "./modules/route-table-subnet-association"
+
+  route_table_id = "rtb-12345678"
+  subnet_ids     = ["subnet-12345678", "subnet-87654321", "subnet-11111111"]
+}
+```
+
+## Input Variables
+
+| Name | Type | Description | Required | Default |
+|------|------|-------------|----------|---------|
+| `route_table_id` | `string` | The ID of the route table to associate with subnets | Yes | - |
+| `subnet_ids` | `list(string)` | List of subnet IDs to associate with the route table | Yes | - |
+
+## Outputs
+
+This module does not export any outputs.
+
+## Important Notes
+
+- **One-to-One**: Each subnet can only be associated with one route table at a time
+- **Automatic Replacement**: If you change a subnet's route table association, Terraform will automatically disassociate the old route table and associate the new one
+- **Default Route Table**: If you don't explicitly associate a subnet with a route table, it uses the VPC's default route table
+- **Common Use Cases**:
+  - Associate public subnets with a route table that has an Internet Gateway route
+  - Associate private subnets with a route table that has a NAT Gateway route
+  - Create separate route tables for different subnet tiers or environments
+
+## Best Practices
+
+- Group subnets by routing requirements (public, private, database)
+- Use descriptive route table names to indicate their purpose
+- Ensure all subnets in a route table have the same routing requirements
+

--- a/main/modules/route-table-subnet-association/variables.tf
+++ b/main/modules/route-table-subnet-association/variables.tf
@@ -1,7 +1,24 @@
 variable "route_table_id" {
-  type = string
+  type        = string
+  description = "The ID of the route table to associate with the subnets."
+
+  validation {
+    condition     = length(var.route_table_id) > 0
+    error_message = "route_table_id cannot be empty."
+  }
 }
 
 variable "subnet_ids" {
-  type = list(string)
+  type        = list(string)
+  description = "List of subnet IDs to associate with the route table. Each subnet can only be associated with one route table at a time."
+
+  validation {
+    condition     = length(var.subnet_ids) > 0
+    error_message = "subnet_ids must contain at least one subnet ID."
+  }
+
+  validation {
+    condition     = length(var.subnet_ids) <= 100
+    error_message = "subnet_ids cannot contain more than 100 subnets."
+  }
 }

--- a/main/modules/route-table/README.md
+++ b/main/modules/route-table/README.md
@@ -1,0 +1,84 @@
+# Route Table Module
+
+This module creates a custom route table for a VPC with a local route and optional additional routes (e.g., to Internet Gateway or NAT Gateway).
+
+## Resources Created
+
+- `aws_route_table` - The route table resource
+
+## Usage
+
+```hcl
+module "public_route_table" {
+  source = "./modules/route-table"
+
+  vpc_id         = "vpc-12345678"
+  vpc_cidr_block = "10.0.0.0/16"
+
+  additional_routes = [
+    {
+      cidr_block = "0.0.0.0/0"
+      gateway_id = "igw-12345678"
+    }
+  ]
+
+  tags = {
+    Name = "main-public-route-table"
+  }
+}
+```
+
+With NAT Gateway:
+
+```hcl
+module "private_route_table" {
+  source = "./modules/route-table"
+
+  vpc_id         = "vpc-12345678"
+  vpc_cidr_block = "10.0.0.0/16"
+
+  additional_routes = [
+    {
+      cidr_block     = "0.0.0.0/0"
+      nat_gateway_id = "nat-12345678"
+    }
+  ]
+
+  tags = {
+    Name = "main-private-route-table"
+  }
+}
+```
+
+## Input Variables
+
+| Name | Type | Description | Required | Default |
+|------|------|-------------|----------|---------|
+| `vpc_id` | `string` | The ID of the VPC | Yes | - |
+| `vpc_cidr_block` | `string` | The CIDR block of the VPC (used for local route) | Yes | - |
+| `additional_routes` | `list(object)` | List of additional routes to add | No | `[]` |
+| `tags` | `map(string)` | A map of tags to assign to the route table | No | `{}` |
+
+## Route Object Structure
+
+Each route in `additional_routes` can have:
+- `cidr_block` (string, required): The destination CIDR block
+- `gateway_id` (string, optional): Internet Gateway ID for public routes
+- `nat_gateway_id` (string, optional): NAT Gateway ID for private routes
+
+**Note**: Each route must specify either `gateway_id` OR `nat_gateway_id`, not both.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `id` | The ID of the route table |
+
+## Notes
+
+- A local route for the VPC CIDR block is automatically added (cannot be removed)
+- Route tables are evaluated in order (most specific route first)
+- You must explicitly associate subnets with route tables using the route-table-subnet-association module
+- Each subnet must be associated with exactly one route table
+- The default route table is created automatically when a VPC is created
+

--- a/main/modules/route-table/variables.tf
+++ b/main/modules/route-table/variables.tf
@@ -1,9 +1,21 @@
 variable "vpc_id" {
-  type = string
+  type        = string
+  description = "The ID of the VPC where the route table will be created."
+
+  validation {
+    condition     = length(var.vpc_id) > 0
+    error_message = "vpc_id cannot be empty."
+  }
 }
 
 variable "vpc_cidr_block" {
-  type = string
+  type        = string
+  description = "The CIDR block of the VPC. Used for the automatic local route (VPC internal traffic)."
+
+  validation {
+    condition     = can(cidrhost(var.vpc_cidr_block, 0))
+    error_message = "vpc_cidr_block must be a valid IPv4 CIDR block."
+  }
 }
 
 variable "additional_routes" {
@@ -12,11 +24,28 @@ variable "additional_routes" {
     gateway_id     = optional(string)
     nat_gateway_id = optional(string)
   }))
+  default     = []
+  description = "List of additional routes to add to the route table. Each route must specify either gateway_id (for Internet Gateway) or nat_gateway_id (for NAT Gateway), not both. The local route for VPC CIDR is automatically added."
 
-  default = []
+  validation {
+    condition = alltrue([
+      for route in var.additional_routes : can(cidrhost(route.cidr_block, 0))
+    ])
+    error_message = "All cidr_block values in additional_routes must be valid IPv4 CIDR blocks."
+  }
+
+  validation {
+    condition = alltrue([
+      for route in var.additional_routes :
+      (route.gateway_id != null) != (route.nat_gateway_id != null) ||
+      (route.gateway_id == null && route.nat_gateway_id == null)
+    ])
+    error_message = "Each route must specify either gateway_id OR nat_gateway_id, not both, or neither if using other route targets."
+  }
 }
 
 variable "tags" {
-  type    = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
+  description = "A map of tags to assign to the route table. Each tag must have a key and value."
 }

--- a/main/modules/route53/README.md
+++ b/main/modules/route53/README.md
@@ -1,0 +1,89 @@
+# Route53 Hosted Zone Module
+
+This module creates an Amazon Route 53 hosted zone for DNS management. Route 53 hosted zones manage how traffic is routed for a domain.
+
+## Resources Created
+
+- `aws_route53_zone` - The Route 53 hosted zone resource
+
+## Usage
+
+```hcl
+module "domain" {
+  source = "./modules/route53"
+
+  name = "example.com"
+
+  tags = {
+    Name = "example.com-zone"
+    Environment = "production"
+  }
+}
+```
+
+For a private hosted zone (within a VPC):
+
+```hcl
+module "private_domain" {
+  source = "./modules/route53"
+
+  name = "internal.example.com"
+
+  tags = {
+    Name = "internal-zone"
+  }
+}
+```
+
+## Input Variables
+
+| Name | Type | Description | Required | Default |
+|------|------|-------------|----------|---------|
+| `name` | `string` | The domain name for the hosted zone (e.g., example.com) | Yes | - |
+| `tags` | `map(string)` | A map of tags to assign to the hosted zone | No | `{}` |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `zone_id` | The hosted zone ID (used for creating DNS records) |
+| `name_servers` | List of name servers to configure with your domain registrar |
+| `arn` | The ARN of the hosted zone |
+
+## Notes
+
+- **Public vs Private**: By default, this creates a public hosted zone. To create a private hosted zone, you would need to add `vpc` blocks to the module
+- **Domain Registration**: Creating a hosted zone does NOT register the domain name. You must register the domain separately
+- **Name Servers**: After creation, Route 53 provides name server records that must be configured with your domain registrar
+- **DNS Records**: Use the hosted zone ID to create A, AAAA, CNAME, and other DNS records
+- **Cost**: Hosted zones have a small monthly fee per zone
+
+## Example: Complete DNS Setup
+
+```hcl
+# 1. Create hosted zone
+module "domain" {
+  source = "./modules/route53"
+  name   = "example.com"
+}
+
+# 2. Output name servers for domain registration
+output "name_servers" {
+  value = module.domain.name_servers
+}
+
+# 3. Output zone ID for creating DNS records
+output "zone_id" {
+  value = module.domain.zone_id
+}
+
+# 4. Configure name servers with your domain registrar
+# 5. Use zone_id to create A, CNAME, MX, etc. records
+```
+
+## Limitations
+
+- The current module implementation creates a basic public hosted zone
+- For private hosted zones, additional VPC configuration would be required
+- No DNS records are created automatically - use separate Route 53 record resources
+

--- a/main/modules/route53/output.tf
+++ b/main/modules/route53/output.tf
@@ -1,0 +1,15 @@
+output "zone_id" {
+  description = "The hosted zone ID"
+  value       = aws_route53_zone.this.zone_id
+}
+
+output "name_servers" {
+  description = "A list of name servers in associated (or default) delegation set"
+  value       = aws_route53_zone.this.name_servers
+}
+
+output "arn" {
+  description = "The ARN of the hosted zone"
+  value       = aws_route53_zone.this.arn
+}
+

--- a/main/modules/route53/variables.tf
+++ b/main/modules/route53/variables.tf
@@ -1,8 +1,20 @@
 variable "name" {
-  type = string
+  type        = string
+  description = "The domain name for the hosted zone (e.g., example.com). Do not include a trailing dot."
+
+  validation {
+    condition     = length(var.name) > 0 && length(var.name) <= 255
+    error_message = "Domain name must be between 1 and 255 characters."
+  }
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$", var.name))
+    error_message = "Domain name must be a valid DNS domain name format."
+  }
 }
 
 variable "tags" {
-  type    = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
+  description = "A map of tags to assign to the Route 53 hosted zone. Each tag must have a key and value."
 }

--- a/main/modules/s3/README.md
+++ b/main/modules/s3/README.md
@@ -1,0 +1,58 @@
+# S3 Bucket Module
+
+This module creates a secure S3 bucket with encryption, versioning, lifecycle policies, and public access blocking enabled.
+
+## Resources Created
+
+- `aws_s3_bucket` - The S3 bucket
+- `aws_s3_bucket_ownership_controls` - Controls for bucket ownership
+- `aws_s3_bucket_acl` - Bucket ACL configuration
+- `aws_s3_bucket_public_access_block` - Public access blocking configuration
+- `aws_s3_bucket_versioning` - Versioning configuration
+- `aws_s3_bucket_lifecycle_configuration` - Lifecycle rules for noncurrent versions
+- `aws_s3_bucket_server_side_encryption_configuration` - Server-side encryption
+
+## Usage
+
+```hcl
+module "terraform_backend" {
+  source = "./modules/s3"
+
+  name = "terraform-common-backend"
+
+  tags = {
+    Name = "terraform-common-backend"
+    Purpose = "Terraform state storage"
+  }
+}
+```
+
+## Input Variables
+
+| Name | Type | Description | Required | Default |
+|------|------|-------------|----------|---------|
+| `name` | `string` | Name of the S3 bucket (must be globally unique) | Yes | - |
+| `tags` | `map(string)` | A map of tags to assign to the S3 bucket | No | `{}` |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `id` | The ID (name) of the S3 bucket |
+| `arn` | The ARN of the S3 bucket |
+
+## Security Features
+
+- **Public Access Blocked**: All public access is blocked by default
+- **Encryption**: AES256 server-side encryption enabled
+- **Versioning**: Enabled to protect against accidental deletion
+- **Lifecycle Rules**: Noncurrent versions expire after 3 days
+
+## Notes
+
+- Bucket names must be globally unique across all AWS accounts
+- Bucket names must be between 3-63 characters
+- Bucket names can only contain lowercase letters, numbers, hyphens, and periods
+- The bucket is configured with ACL set to "private"
+- Noncurrent versions are automatically deleted after 3 days to save costs
+

--- a/main/modules/s3/variables.tf
+++ b/main/modules/s3/variables.tf
@@ -1,8 +1,20 @@
 variable "name" {
-  type = string
+  type        = string
+  description = "Name of the S3 bucket. Must be globally unique and comply with S3 bucket naming rules."
+
+  validation {
+    condition     = length(var.name) >= 3 && length(var.name) <= 63
+    error_message = "S3 bucket name must be between 3 and 63 characters."
+  }
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9.-]*[a-z0-9]$", var.name)) || can(regex("^[a-z0-9]+$", var.name))
+    error_message = "S3 bucket name must start and end with a lowercase letter or number, and can only contain lowercase letters, numbers, hyphens, and periods."
+  }
 }
 
 variable "tags" {
-  type    = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
+  description = "A map of tags to assign to the S3 bucket."
 }

--- a/main/modules/security-group-egress/README.md
+++ b/main/modules/security-group-egress/README.md
@@ -1,0 +1,88 @@
+# Security Group Egress Module
+
+This module adds an egress (outbound) rule to an existing security group for both IPv4 and IPv6 traffic. Egress rules control what outbound traffic is allowed from resources associated with the security group.
+
+## Resources Created
+
+- `aws_vpc_security_group_egress_rule` (IPv4) - Egress rule for IPv4 traffic
+- `aws_vpc_security_group_egress_rule` (IPv6) - Egress rule for IPv6 traffic
+
+## Usage
+
+```hcl
+module "web_egress" {
+  source = "./modules/security-group-egress"
+
+  security_group_id   = "sg-12345678"
+  security_group_name = "web-servers-sg"
+  from_port           = 443
+  to_port             = 443
+  ip_protocol         = "TCP"
+  cidr_ipv4           = "0.0.0.0/0"
+  cidr_ipv6           = "::/0"
+
+  tags = {
+    Name = "https-egress-rule"
+  }
+}
+```
+
+Allow all outbound traffic:
+
+```hcl
+module "all_egress" {
+  source = "./modules/security-group-egress"
+
+  security_group_id   = module.security_group.id
+  security_group_name = module.security_group.name
+  from_port           = -1
+  to_port             = -1
+  ip_protocol         = "-1"
+  cidr_ipv4           = "0.0.0.0/0"
+  cidr_ipv6           = "::/0"
+}
+```
+
+## Input Variables
+
+| Name | Type | Description | Required | Default |
+|------|------|-------------|----------|---------|
+| `security_group_id` | `string` | The ID of the security group to add the rule to | Yes | - |
+| `security_group_name` | `string` | Name of the security group (used for tagging) | Yes | - |
+| `cidr_ipv4` | `string` | IPv4 CIDR block to allow traffic to | Yes | - |
+| `cidr_ipv6` | `string` | IPv6 CIDR block to allow traffic to (null to disable) | Yes | - |
+| `from_port` | `number` | Starting port number (-1 for all ports) | Yes | - |
+| `to_port` | `number` | Ending port number (-1 for all ports) | Yes | - |
+| `ip_protocol` | `string` | IP protocol (tcp, udp, icmp, -1, or protocol number) | Yes | - |
+| `tags` | `map(string)` | A map of tags to assign to the egress rule | No | `{}` |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `id` | The ID of the IPv4 egress rule |
+| `arn` | The ARN of the IPv4 egress rule |
+
+## Common Use Cases
+
+- **Internet Access**: Allow outbound HTTPS (443) to access external APIs
+- **Database Access**: Allow outbound to database port (e.g., 5432 for PostgreSQL) in specific CIDR
+- **All Traffic**: Allow all outbound traffic (common for web servers)
+- **Restricted Access**: Limit outbound traffic to specific CIDR blocks for security
+
+## Notes
+
+- Security groups are **stateful**: if you allow outbound traffic, the response is automatically allowed inbound
+- Ports range from -1 (all ports) to 65535
+- Use `-1` for protocol and ports to allow all traffic
+- Common protocols: TCP (6), UDP (17), ICMP (1)
+- IPv6 rule is only created if `cidr_ipv6` is not null or empty
+- By default, security groups allow all outbound traffic, but explicit rules provide better security and documentation
+
+## Security Best Practices
+
+- Follow the principle of least privilege - only allow necessary outbound traffic
+- Restrict egress to specific CIDR blocks when possible
+- Use specific port ranges instead of allowing all ports
+- Document the purpose of egress rules with tags
+

--- a/main/modules/security-group-egress/variables.tf
+++ b/main/modules/security-group-egress/variables.tf
@@ -1,32 +1,65 @@
 variable "security_group_id" {
-  type = string
+  type        = string
+  description = "The ID of the security group to add the egress rule to."
 }
 
 variable "security_group_name" {
-  type = string
+  type        = string
+  description = "Name of the security group (used for tagging)."
 }
 
 variable "cidr_ipv4" {
-  type = string
+  type        = string
+  description = "IPv4 CIDR block to allow traffic to. Use '0.0.0.0/0' for all IPv4 addresses, or a specific CIDR block for restricted access."
+
+  validation {
+    condition     = var.cidr_ipv4 == null || can(cidrhost(var.cidr_ipv4, 0))
+    error_message = "cidr_ipv4 must be a valid IPv4 CIDR block or null."
+  }
 }
 
 variable "cidr_ipv6" {
-  type = string
+  type        = string
+  description = "IPv6 CIDR block to allow traffic to. Use '::/0' for all IPv6 addresses, or null/empty string to disable IPv6."
+
+  validation {
+    condition     = var.cidr_ipv6 == null || var.cidr_ipv6 == "" || can(cidrhost(var.cidr_ipv6, 0))
+    error_message = "cidr_ipv6 must be a valid IPv6 CIDR block, empty string, or null."
+  }
 }
 
 variable "from_port" {
-  type = number
+  type        = number
+  description = "Starting port number. Use -1 for all ports (with protocol -1)."
+
+  validation {
+    condition     = var.from_port >= -1 && var.from_port <= 65535
+    error_message = "from_port must be between -1 and 65535."
+  }
 }
 
 variable "to_port" {
-  type = number
+  type        = number
+  description = "Ending port number. Use -1 for all ports (with protocol -1). Must be >= from_port."
+
+  validation {
+    condition     = var.to_port >= -1 && var.to_port <= 65535
+    error_message = "to_port must be between -1 and 65535."
+  }
 }
 
 variable "ip_protocol" {
-  type = string
+  type        = string
+  description = "IP protocol. Use 'tcp', 'udp', 'icmp', '-1' for all protocols, or protocol number."
+
+  validation {
+    condition     = contains(["tcp", "udp", "icmp", "-1", "6", "17", "1"], lower(var.ip_protocol)) || can(tonumber(var.ip_protocol))
+    error_message = "ip_protocol must be a valid protocol name (tcp, udp, icmp) or number, or '-1' for all."
+  }
 }
 
 variable "tags" {
-  type    = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
+  description = "A map of tags to assign to the security group egress rule."
 }

--- a/main/modules/security-group-ingress/README.md
+++ b/main/modules/security-group-ingress/README.md
@@ -1,0 +1,56 @@
+# Security Group Ingress Module
+
+This module adds an ingress (inbound) rule to an existing security group for both IPv4 and IPv6 traffic.
+
+## Resources Created
+
+- `aws_vpc_security_group_ingress_rule` (IPv4) - Ingress rule for IPv4 traffic
+- `aws_vpc_security_group_ingress_rule` (IPv6) - Ingress rule for IPv6 traffic
+
+## Usage
+
+```hcl
+module "ssh_ingress" {
+  source = "./modules/security-group-ingress"
+
+  security_group_id   = "sg-12345678"
+  security_group_name = "web-servers-sg"
+  from_port           = 22
+  to_port             = 22
+  ip_protocol         = "TCP"
+  cidr_ipv4           = "10.0.0.0/16"
+  cidr_ipv6           = null
+
+  tags = {
+    Name = "ssh-ingress-rule"
+  }
+}
+```
+
+## Input Variables
+
+| Name | Type | Description | Required | Default |
+|------|------|-------------|----------|---------|
+| `security_group_id` | `string` | The ID of the security group to add the rule to | Yes | - |
+| `security_group_name` | `string` | Name of the security group (used for tagging) | Yes | - |
+| `cidr_ipv4` | `string` | IPv4 CIDR block to allow traffic from | Yes | - |
+| `cidr_ipv6` | `string` | IPv6 CIDR block to allow traffic from (null to disable) | Yes | - |
+| `from_port` | `number` | Starting port number (-1 for all ports) | Yes | - |
+| `to_port` | `number` | Ending port number (-1 for all ports) | Yes | - |
+| `ip_protocol` | `string` | IP protocol (tcp, udp, icmp, -1, or protocol number) | Yes | - |
+| `tags` | `map(string)` | A map of tags to assign to the rule | No | `{}` |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `ipv4_rule_id` | The ID of the IPv4 ingress rule |
+| `ipv6_rule_id` | The ID of the IPv6 ingress rule |
+
+## Notes
+
+- Ports range from -1 (all ports) to 65535
+- Use `-1` for protocol and ports to allow all traffic
+- Common protocols: TCP (6), UDP (17), ICMP (1)
+- IPv6 rule is only created if `cidr_ipv6` is not null or empty
+

--- a/main/modules/security-group-ingress/variables.tf
+++ b/main/modules/security-group-ingress/variables.tf
@@ -1,32 +1,65 @@
 variable "security_group_id" {
-  type = string
+  type        = string
+  description = "The ID of the security group to add the ingress rule to."
 }
 
 variable "security_group_name" {
-  type = string
+  type        = string
+  description = "Name of the security group (used for tagging)."
 }
 
 variable "cidr_ipv4" {
-  type = string
+  type        = string
+  description = "IPv4 CIDR block to allow traffic from. Use '0.0.0.0/0' for all IPv4 addresses, or a specific CIDR block for restricted access."
+
+  validation {
+    condition     = var.cidr_ipv4 == null || can(cidrhost(var.cidr_ipv4, 0))
+    error_message = "cidr_ipv4 must be a valid IPv4 CIDR block or null."
+  }
 }
 
 variable "cidr_ipv6" {
-  type = string
+  type        = string
+  description = "IPv6 CIDR block to allow traffic from. Use '::/0' for all IPv6 addresses, or null/empty string to disable IPv6."
+
+  validation {
+    condition     = var.cidr_ipv6 == null || var.cidr_ipv6 == "" || can(cidrhost(var.cidr_ipv6, 0))
+    error_message = "cidr_ipv6 must be a valid IPv6 CIDR block, empty string, or null."
+  }
 }
 
 variable "from_port" {
-  type = number
+  type        = number
+  description = "Starting port number. Use -1 for all ports (with protocol -1)."
+
+  validation {
+    condition     = var.from_port >= -1 && var.from_port <= 65535
+    error_message = "from_port must be between -1 and 65535."
+  }
 }
 
 variable "to_port" {
-  type = number
+  type        = number
+  description = "Ending port number. Use -1 for all ports (with protocol -1). Must be >= from_port."
+
+  validation {
+    condition     = var.to_port >= -1 && var.to_port <= 65535
+    error_message = "to_port must be between -1 and 65535."
+  }
 }
 
 variable "ip_protocol" {
-  type = string
+  type        = string
+  description = "IP protocol. Use 'tcp', 'udp', 'icmp', '-1' for all protocols, or protocol number."
+
+  validation {
+    condition     = contains(["tcp", "udp", "icmp", "-1", "6", "17", "1"], lower(var.ip_protocol)) || can(tonumber(var.ip_protocol))
+    error_message = "ip_protocol must be a valid protocol name (tcp, udp, icmp) or number, or '-1' for all."
+  }
 }
 
 variable "tags" {
-  type    = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
+  description = "A map of tags to assign to the security group ingress rule."
 }

--- a/main/modules/security-group/README.md
+++ b/main/modules/security-group/README.md
@@ -1,0 +1,46 @@
+# Security Group Module
+
+This module creates an AWS Security Group within a VPC. Security groups act as virtual firewalls to control inbound and outbound traffic.
+
+## Resources Created
+
+- `aws_security_group` - The security group resource
+
+## Usage
+
+```hcl
+module "web_security_group" {
+  source = "./modules/security-group"
+
+  name   = "web-servers"
+  vpc_id = "vpc-12345678"
+
+  tags = {
+    Name = "web-servers-sg"
+  }
+}
+```
+
+## Input Variables
+
+| Name | Type | Description | Required | Default |
+|------|------|-------------|----------|---------|
+| `name` | `string` | Name prefix for the security group (full name will be '{name}-sg') | Yes | - |
+| `vpc_id` | `string` | The ID of the VPC where the security group will be created | Yes | - |
+| `tags` | `map(string)` | A map of tags to assign to the security group | No | `{}` |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `id` | The ID of the security group |
+| `name` | The name of the security group |
+| `arn` | The ARN of the security group |
+
+## Notes
+
+- Security groups are stateful: if you send a request from your instance, the response traffic is automatically allowed
+- By default, security groups deny all inbound traffic and allow all outbound traffic
+- Use security-group-ingress and security-group-egress modules to add rules
+- Security group names must be unique within the VPC
+

--- a/main/modules/security-group/variables.tf
+++ b/main/modules/security-group/variables.tf
@@ -1,12 +1,20 @@
 variable "name" {
-  type = string
+  type        = string
+  description = "Name prefix for the security group. The full name will be '{name}-sg'."
+
+  validation {
+    condition     = length(var.name) > 0 && length(var.name) <= 255
+    error_message = "name must be between 1 and 255 characters."
+  }
 }
 
 variable "vpc_id" {
-  type = string
+  type        = string
+  description = "The ID of the VPC where the security group will be created."
 }
 
 variable "tags" {
-  type    = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
+  description = "A map of tags to assign to the security group."
 }

--- a/main/modules/subnet/README.md
+++ b/main/modules/subnet/README.md
@@ -1,0 +1,54 @@
+# Subnet Module
+
+This module creates one or more subnets within a VPC across multiple availability zones.
+
+## Resources Created
+
+- `aws_subnet` - One or more subnets based on the number of CIDR blocks provided
+
+## Usage
+
+```hcl
+module "public_subnets" {
+  source = "./modules/subnet"
+
+  vpc_id             = "vpc-12345678"
+  cidr_blocks        = ["10.0.0.0/20", "10.0.16.0/20", "10.0.32.0/20"]
+  availability_zones = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  auto_assign_public_ip = true
+  name_prefix        = "main"
+  
+  tags = {
+    Tier = "public"
+  }
+}
+```
+
+## Input Variables
+
+| Name | Type | Description | Required | Default |
+|------|------|-------------|----------|---------|
+| `vpc_id` | `string` | The ID of the VPC where subnets will be created | Yes | - |
+| `cidr_blocks` | `list(string)` | List of CIDR blocks for the subnets | Yes | - |
+| `availability_zones` | `list(string)` | List of availability zones (must match CIDR blocks count) | Yes | - |
+| `auto_assign_public_ip` | `bool` | Whether to automatically assign public IP addresses | No | `false` |
+| `name_prefix` | `string` | Prefix for subnet names | No | `""` |
+| `tags` | `map(string)` | A map of tags to assign to the subnets | No | `{}` |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `ids` | List of subnet IDs |
+
+## Validation
+
+- Number of CIDR blocks must match number of availability zones
+- CIDR blocks must be valid IPv4 CIDR notation
+- Subnet count limited to 6 (AWS limit per availability zone)
+
+## Notes
+
+- Subnet names are automatically generated based on prefix, tier (public/private), and index
+- Each subnet is created in a different availability zone for high availability
+

--- a/main/modules/subnet/main.tf
+++ b/main/modules/subnet/main.tf
@@ -1,9 +1,18 @@
+locals {
+  # Validate that CIDR blocks and availability zones match in count
+  subnet_count = length(var.cidr_blocks)
+  az_count     = length(var.availability_zones)
+
+  # This will cause a clear error if counts don't match
+  validate_counts = local.subnet_count != local.az_count ? tobool("ERROR: Number of CIDR blocks (${local.subnet_count}) must match number of availability zones (${local.az_count}).") : true
+}
+
 resource "aws_subnet" "this" {
-  count = length(var.cidr_blocks)
+  count = local.subnet_count
 
   vpc_id                  = var.vpc_id
   cidr_block              = var.cidr_blocks[count.index]
-  availability_zone       = element(var.availability_zones, count.index)
+  availability_zone       = var.availability_zones[count.index]
   map_public_ip_on_launch = var.auto_assign_public_ip
 
   tags = merge(var.tags, {

--- a/main/modules/subnet/variables.tf
+++ b/main/modules/subnet/variables.tf
@@ -1,26 +1,49 @@
 variable "vpc_id" {
-  type = string
+  type        = string
+  description = "The ID of the VPC where the subnets will be created."
 }
 
 variable "cidr_blocks" {
-  type = list(string)
+  type        = list(string)
+  description = "List of CIDR blocks for the subnets. The number of CIDR blocks must match the number of availability zones."
+
+  validation {
+    condition     = length(var.cidr_blocks) > 0 && length(var.cidr_blocks) <= 6
+    error_message = "cidr_blocks must contain between 1 and 6 CIDR blocks."
+  }
+
+  validation {
+    condition = alltrue([
+      for cidr in var.cidr_blocks : can(cidrhost(cidr, 0))
+    ])
+    error_message = "All CIDR blocks must be valid IPv4 CIDR blocks."
+  }
 }
 
 variable "availability_zones" {
-  type = list(string)
+  type        = list(string)
+  description = "List of availability zones where subnets will be created. Length must match cidr_blocks. Note: Validation ensures count matches in the module's locals."
+
+  validation {
+    condition     = length(var.availability_zones) > 0 && length(var.availability_zones) <= 6
+    error_message = "availability_zones must contain between 1 and 6 availability zones."
+  }
 }
 
 variable "auto_assign_public_ip" {
-  type    = bool
-  default = false
+  type        = bool
+  default     = false
+  description = "Whether to automatically assign public IP addresses to instances launched in these subnets. Set to true for public subnets."
 }
 
 variable "name_prefix" {
-  type    = string
-  default = ""
+  type        = string
+  default     = ""
+  description = "Prefix to add to subnet names. Used for naming convention."
 }
 
 variable "tags" {
-  type    = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
+  description = "A map of tags to assign to the subnets."
 }

--- a/main/modules/vpc-flow-logs/README.md
+++ b/main/modules/vpc-flow-logs/README.md
@@ -1,0 +1,65 @@
+# VPC Flow Logs Module
+
+This module enables VPC Flow Logs for network traffic monitoring and security analysis. Flow logs capture information about IP traffic going to and from network interfaces in your VPC.
+
+## Resources Created
+
+- `aws_cloudwatch_log_group` - CloudWatch Log Group for storing flow logs
+- `aws_iam_role` - IAM role for VPC Flow Logs service
+- `aws_iam_role_policy` - IAM policy allowing logs to be written to CloudWatch
+- `aws_flow_log` - VPC Flow Log resource
+
+## Usage
+
+```hcl
+module "vpc_flow_logs" {
+  source = "./modules/vpc-flow-logs"
+
+  vpc_id         = "vpc-12345678"
+  name_prefix    = "main"
+  log_group_name = "/aws/vpc/main-flow-logs"
+  
+  log_retention_days = 30
+  traffic_type       = "ALL"
+
+  tags = {
+    Name = "main-vpc-flow-logs"
+  }
+}
+```
+
+## Input Variables
+
+| Name | Type | Description | Required | Default |
+|------|------|-------------|----------|---------|
+| `vpc_id` | `string` | The ID of the VPC to enable flow logs for | Yes | - |
+| `name_prefix` | `string` | Prefix for naming resources | No | `"vpc-flow-logs"` |
+| `log_group_name` | `string` | Name of the CloudWatch Log Group | Yes | - |
+| `log_retention_days` | `number` | Number of days to retain logs | No | `30` |
+| `traffic_type` | `string` | Type of traffic to log (ACCEPT, REJECT, ALL) | No | `"ALL"` |
+| `kms_key_id` | `string` | KMS key ARN for log encryption | No | `null` |
+| `tags` | `map(string)` | A map of tags to assign to resources | No | `{}` |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `flow_log_id` | The Flow Log ID |
+| `log_group_name` | The name of the CloudWatch Log Group |
+| `log_group_arn` | The ARN of the CloudWatch Log Group |
+| `iam_role_arn` | The ARN of the IAM role used for VPC Flow Logs |
+
+## Features
+
+- CloudWatch Logs integration for centralized logging
+- Configurable log retention period
+- Optional KMS encryption
+- Automatic IAM role and policy creation
+- Supports logging ACCEPT, REJECT, or ALL traffic
+
+## Notes
+
+- Flow logs can help with troubleshooting connectivity and security issues
+- Valid log retention days: 0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653
+- Traffic type ALL logs both accepted and rejected traffic
+

--- a/main/modules/vpc-flow-logs/main.tf
+++ b/main/modules/vpc-flow-logs/main.tf
@@ -1,0 +1,70 @@
+resource "aws_cloudwatch_log_group" "vpc_flow_logs" {
+  name              = var.log_group_name
+  retention_in_days = var.log_retention_days
+  kms_key_id        = var.kms_key_id
+
+  tags = merge(var.tags, {
+    Name = var.log_group_name
+  })
+}
+
+resource "aws_iam_role" "vpc_flow_logs" {
+  name = "${var.name_prefix}-vpc-flow-logs-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "vpc-flow-logs.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-vpc-flow-logs-role"
+  })
+}
+
+resource "aws_iam_role_policy" "vpc_flow_logs" {
+  name = "${var.name_prefix}-vpc-flow-logs-policy"
+  role = aws_iam_role.vpc_flow_logs.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams"
+        ]
+        Effect   = "Allow"
+        Resource = "${aws_cloudwatch_log_group.vpc_flow_logs.arn}:*"
+      }
+    ]
+  })
+}
+
+resource "aws_flow_log" "vpc" {
+  iam_role_arn         = aws_iam_role.vpc_flow_logs.arn
+  log_destination      = aws_cloudwatch_log_group.vpc_flow_logs.arn
+  log_destination_type = "cloud-watch-logs"
+  vpc_id               = var.vpc_id
+  traffic_type         = var.traffic_type
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-vpc-flow-log"
+  })
+
+  depends_on = [
+    aws_cloudwatch_log_group.vpc_flow_logs,
+    aws_iam_role_policy.vpc_flow_logs
+  ]
+}
+

--- a/main/modules/vpc-flow-logs/output.tf
+++ b/main/modules/vpc-flow-logs/output.tf
@@ -1,0 +1,20 @@
+output "flow_log_id" {
+  description = "The Flow Log ID"
+  value       = aws_flow_log.vpc.id
+}
+
+output "log_group_name" {
+  description = "The name of the CloudWatch Log Group"
+  value       = aws_cloudwatch_log_group.vpc_flow_logs.name
+}
+
+output "log_group_arn" {
+  description = "The ARN of the CloudWatch Log Group"
+  value       = aws_cloudwatch_log_group.vpc_flow_logs.arn
+}
+
+output "iam_role_arn" {
+  description = "The ARN of the IAM role used for VPC Flow Logs"
+  value       = aws_iam_role.vpc_flow_logs.arn
+}
+

--- a/main/modules/vpc-flow-logs/variables.tf
+++ b/main/modules/vpc-flow-logs/variables.tf
@@ -1,0 +1,57 @@
+variable "vpc_id" {
+  type        = string
+  description = "The ID of the VPC to enable flow logs for."
+}
+
+variable "name_prefix" {
+  type        = string
+  description = "Prefix for naming resources (log group, IAM role, etc.)."
+  default     = "vpc-flow-logs"
+}
+
+variable "log_group_name" {
+  type        = string
+  description = "Name of the CloudWatch Log Group for VPC Flow Logs."
+
+  validation {
+    condition     = length(var.log_group_name) > 0 && length(var.log_group_name) <= 512
+    error_message = "log_group_name must be between 1 and 512 characters."
+  }
+}
+
+variable "log_retention_days" {
+  type        = number
+  description = "Number of days to retain logs in CloudWatch. Valid values: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, or 0 (never expire)."
+  default     = 30
+
+  validation {
+    condition = contains([
+      0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653
+    ], var.log_retention_days)
+    error_message = "log_retention_days must be a valid CloudWatch log retention value."
+  }
+}
+
+variable "traffic_type" {
+  type        = string
+  description = "Type of traffic to log. Valid values: ACCEPT, REJECT, or ALL."
+  default     = "ALL"
+
+  validation {
+    condition     = contains(["ACCEPT", "REJECT", "ALL"], upper(var.traffic_type))
+    error_message = "traffic_type must be ACCEPT, REJECT, or ALL."
+  }
+}
+
+variable "kms_key_id" {
+  type        = string
+  description = "The ARN of the KMS key to use for encrypting log data. If not specified, logs are encrypted with the default CloudWatch Logs encryption."
+  default     = null
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "A map of tags to assign to the VPC Flow Logs resources."
+}
+

--- a/main/modules/vpc/README.md
+++ b/main/modules/vpc/README.md
@@ -1,0 +1,54 @@
+# VPC Module
+
+This module creates a Virtual Private Cloud (VPC) with DNS support and default route tables, network ACLs, and security groups.
+
+## Resources Created
+
+- `aws_vpc` - The main VPC resource
+- `aws_default_route_table` - Default route table for the VPC
+- `aws_default_network_acl` - Default network ACL for the VPC
+- `aws_default_security_group` - Default security group for the VPC
+
+## Usage
+
+```hcl
+module "vpc" {
+  source = "./modules/vpc"
+
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name        = "main-vpc"
+    Environment = "production"
+  }
+}
+```
+
+## Input Variables
+
+| Name | Type | Description | Required | Default |
+|------|------|-------------|----------|---------|
+| `cidr_block` | `string` | The CIDR block for the VPC (e.g., 10.0.0.0/16) | Yes | - |
+| `tags` | `map(string)` | A map of tags to assign to the VPC and related resources | No | `{}` |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `id` | The ID of the VPC |
+| `cidr_block` | The CIDR block of the VPC |
+
+## Features
+
+- DNS hostnames enabled
+- DNS support enabled
+- Default route table configured with local route
+- Default network ACL configured
+- Default security group configured
+
+## Notes
+
+- The VPC automatically creates default resources (route table, network ACL, security group)
+- Default security group allows all egress and self-referencing ingress
+- Default network ACL allows all traffic
+

--- a/main/modules/vpc/main.tf
+++ b/main/modules/vpc/main.tf
@@ -2,7 +2,7 @@ resource "aws_vpc" "this" {
   cidr_block           = var.cidr_block
   instance_tenancy     = "default"
   enable_dns_hostnames = true
-
+  enable_dns_support   = true
 
   tags = var.tags
 }

--- a/main/modules/vpc/variables.tf
+++ b/main/modules/vpc/variables.tf
@@ -1,8 +1,15 @@
 variable "cidr_block" {
-  type = string
+  type        = string
+  description = "The CIDR block for the VPC. Must be a valid IPv4 CIDR block (e.g., 10.0.0.0/16)."
+
+  validation {
+    condition     = can(cidrhost(var.cidr_block, 0))
+    error_message = "cidr_block must be a valid IPv4 CIDR block."
+  }
 }
 
 variable "tags" {
-  type    = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
+  description = "A map of tags to assign to the VPC and related resources. Each tag must have a key and value."
 }

--- a/main/variables.tf
+++ b/main/variables.tf
@@ -1,3 +1,9 @@
 variable "github_project_url" {
-  type = string
+  type        = string
+  description = "GitHub project URL used for tagging resources. Used in default tags for the AWS provider."
+
+  validation {
+    condition     = can(regex("^https?://", var.github_project_url)) || var.github_project_url == ""
+    error_message = "github_project_url must be a valid URL starting with http:// or https://, or an empty string."
+  }
 }


### PR DESCRIPTION
- Add DNS support to VPC (enable_dns_support = true)
- Add comprehensive variable descriptions and validation to all modules
- Add error handling and validation for CIDR blocks, availability zones, and subnet counts
- Create VPC Flow Logs module with CloudWatch integration
- Add README.md documentation for all modules (15 modules)
- Add Route53 output file with zone_id, name_servers, and arn
- Fix VPC Flow Logs resource configuration (use vpc_id instead of resource_id/resource_type)
- Add availability zone count validation in main.tf
- Improve subnet module with count validation between CIDR blocks and AZs

All modules now have:
- Complete variable descriptions
- Input validation blocks
- Comprehensive README documentation
- Usage examples